### PR TITLE
Feature: assert that kdbx version is 3.1

### DIFF
--- a/lib/keepass/database/header.go
+++ b/lib/keepass/database/header.go
@@ -205,6 +205,9 @@ func (h *header) read(stream *os.File) error {
 	if err != nil {
 		return err
 	}
+	if h.version.major != 3 || h.version.minor != 1 {
+		return FileError(errors.New("Only kdbx version 3.1 is supported"))
+	}
 
 	headerMap := make(map[headerCode][]byte)
 	bufType := make([]byte, TLV_TYPE_LEN)


### PR DESCRIPTION
Since we only support kdbx version 3.1 for now, it makes sense to assert that when loading a database.