### PR TITLE
Feature: load database before starting tui

### DIFF
--- a/cmd/tresor/main.go
+++ b/cmd/tresor/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Zaphoood/tresor/lib/keepass/database"
 	"github.com/Zaphoood/tresor/pkg/tui"
 	"github.com/Zaphoood/tresor/pkg/util"
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,9 +24,19 @@ func main() {
 		return
 	}
 
-	p := tea.NewProgram(tui.NewMainModel(path), tea.WithAltScreen())
+	var d *database.Database = nil
+	if len(path) > 0 {
+		d = database.New(path)
+		err = d.Load()
+		if err != nil {
+			fmt.Printf("Error while opening %s: %s\n", path, err)
+			return
+		}
+	}
+
+	p := tea.NewProgram(tui.NewMainModel(d), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
-		fmt.Printf("Error: %s", err)
+		fmt.Printf("Error while running TUI: %s", err)
 		os.Exit(1)
 	}
 }

--- a/lib/keepass/database/database.go
+++ b/lib/keepass/database/database.go
@@ -50,8 +50,8 @@ type Database struct {
 	parsed     *parser.Document
 }
 
-func New(path string) Database {
-	return Database{
+func New(path string) *Database {
+	return &Database{
 		path: path,
 	}
 }

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -32,7 +32,7 @@ func fileSelectedCmd(path string) tea.Cmd {
 		if err != nil {
 			return loadFailedMsg{err}
 		}
-		return loadDoneMsg{&db}
+		return loadDoneMsg{db}
 	}
 }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -34,17 +34,15 @@ func NewMainModel(d *database.Database) MainModel {
 }
 
 func (m MainModel) Init() tea.Cmd {
+	if m.database != nil {
+		return func() tea.Msg { return loadDoneMsg{m.database} }
+	}
 	return nil
 }
 
 func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	var cmds []tea.Cmd
-
-	if m.database != nil {
-		cmds = append(cmds, m.initDecryptView(m.database))
-		m.database = nil
-	}
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
When a file path is passed as a command line argument, try to load the database first, before starting the TUI.
This way, errors (non-existent path, invalid format etc.) are immedeatly reported instead of launching the TUI interface just to show the error message.