### PR TITLE
feat: copy with y key instead of Enter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To open a file, run `tresor <file>`. Alternatively, run just `tresor` and input 
 After inputting your password, the KeePass database should open.
 Navigate using the `h`, `j`, `k` and `l` keys, type `:q` and hit <kbd>Enter</kbd> to exit.
 
-When hovering over an entry, press <kbd>Enter</kbd> to copy its password to the system clipboard. The clipboard will be cleared automatically after ten seconds.
+When hovering over an entry, press `y` to copy its password to the system clipboard. The clipboard will be cleared automatically after ten seconds.
 
 Commands work just like in vim: To execute a command, type `:` followed by the command and press <kbd>Enter</kbd>.
 These commands are currently available:

--- a/src/tui/navigate.go
+++ b/src/tui/navigate.go
@@ -319,7 +319,7 @@ func (n Navigate) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "ctrl+c":
 				n.cmdLine.SetMessage("Type  :q  and press <Enter> to exit tresor")
-			case "enter":
+			case "y":
 				cmd := n.copyToClipboard()
 				return n, cmd
 			case "l":


### PR DESCRIPTION
Makes the behavior more similar to vim